### PR TITLE
Use sprockets virtual paths in frontend manifest

### DIFF
--- a/app/assets/javascripts/solidus_paypal_braintree/frontend.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/frontend.js
@@ -4,8 +4,8 @@
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // the compiled file.
 //
-//= require ./constants
-//= require ./promise
-//= require ./client
-//= require ./hosted_form
-//= require ./paypal_button
+//= require solidus_paypal_braintree/constants
+//= require solidus_paypal_braintree/promise
+//= require solidus_paypal_braintree/client
+//= require solidus_paypal_braintree/hosted_form
+//= require solidus_paypal_braintree/paypal_button


### PR DESCRIPTION
When using relatives paths it is not possible for host
apps to overwrite individual files. We need to use the full
virtual path from Sprockets in order to make this work.