### PR TITLE
Lazy init the frontend js

### DIFF
--- a/app/assets/javascripts/solidus_paypal_braintree/checkout.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/checkout.js
@@ -57,6 +57,9 @@ $(function() {
   var $hostedFields = $("[data-braintree-hosted-fields]");
   var $submitButton = $("input[type='submit']", $paymentForm);
 
+  // Init solidus_paypal_braintree checkout code, now that we now everything is loaded.
+  SolidusPaypalBraintree.init();
+
   // If we're not using hosted fields, the form doesn't need to wait.
   if ($hostedFields.length > 0) {
     disableSubmit();

--- a/app/assets/javascripts/solidus_paypal_braintree/constants.js
+++ b/app/assets/javascripts/solidus_paypal_braintree/constants.js
@@ -1,10 +1,20 @@
 SolidusPaypalBraintree = {
   APPLY_PAY_API_VERSION: 1,
 
+  /*
+   * Invoke this when you are sure that Spree.pathFor is available.
+   * This will most of the time be on DOMContentLoaded
+   */
+  init: function init() {
+    // Need to override the paths dynamically, as we don't know the Solidus engine mount point while loading this file.
+    this.config.paths.clientTokens = Spree.pathFor('solidus_paypal_braintree/client_token');
+    this.config.paths.transactions = Spree.pathFor('solidus_paypal_braintree/transactions');
+  },
+
   config: {
     paths: {
-      clientTokens: Spree.pathFor('solidus_paypal_braintree/client_token'),
-      transactions: Spree.pathFor('solidus_paypal_braintree/transactions')
+      clientTokens: '/solidus_paypal_braintree/client_token',
+      transactions: '/solidus_paypal_braintree/transactions'
     },
 
     // Override to provide your own error messages.


### PR DESCRIPTION
When loading javscript asynchronously we can't be sure that `Spree.pathFor` is already available while parsing the `constants.js` file. So instead we postbone the SolidusPaypalBraintree initialization after DOM ready.